### PR TITLE
Parser submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,19 +41,25 @@ At the moment, this feature only works within individual mapper objects.
 - `array_data` option on AnnotationLayerConfig for simple cases where you just want to map Nx3 arrays to points, a pair of Nx3 arrays to lines, or an Nx3 + N array to spheres (centers+radii).
 
 ### Fixed
+
 - Bug in GL Shader that caused StateBuilder to fail when `constrast_controls` was set to True.
 
 ## [2.0.2] - 2020-06-18
 
 ### Added
+
 - Custom GL Shaders (see [documentation](https://github.com/google/neuroglancer/blob/a12552d03844fb6092cf300171d2f2077b3960e2/src/neuroglancer/sliceview/image_layer_rendering.md)) for image and segmentation layers can be set in EasyViewer.
+
 - JSON State Server can be set in EasyViewer.
+
 - Added `contrast_controls` argument to `statebuilder.ImageLayerConfig` to provide brightness/contrast controls to layer through GL Shader.
+
 - Added `state_server` argument to `statebuilder.StateBuilder` to pre-set state server endpoints.
 
 ## [2.0.1] - 2020-04-27
 
 ### Fixed
+
 - Removed unnecessary parts of the included neuroglancer module (`nglite`) for cleanliness.
 
 ## [2.0.0] - 2020-04-25
@@ -61,11 +67,15 @@ At the moment, this feature only works within individual mapper objects.
 This update significantly changed the underlying nature and goals of the Neuroglancer Annotation UI project.
 
 ### Added
+
 - StateBuilder module for rule-based method of generating Neuroglancer states from Pandas DataFrames.
+
 - Added various features to make use of specific aspects of the Seung-lab Neuroglancer fork.
 
 ### Changed
+
 - Removed dependency on neuroglancer python package, which was not designed for the Seung-Lab Neuroglancer fork and had some difficult install requirements for features that were unnecessary for this project demanded.
 
 ### Removed
+
 - Dynamic state management via python server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 This project attempts to follow [Semantic Versioning](https://semver.org) and uses [Keep-a-Changelog formatting](https://keepachangelog.com/en/1.0.0/). But I make mistakes sometimes.
 
 <!-- ## Unreleased -->
+## [2.2.0] — 2020-09-04
+
+### Added
+
+- Parser submodule `nglui.parser` for quickly extracting data from neuroglancer states.
+This should remove some of the boilerplate one writes every time you want to get data out of a state.
+
+- AnnotationLayerConfig now can take arguments about user interactions such as filtering by segmentation and bracket shortcuts showing segmentations.
+
+### Changed
+
+- Default behavior for annotation layers now has filtering by segmentation turned off and bracket shortcuts showing segmentations turned on.
+
+## [2.1.1] — 2020-08-17
+
+### Changed
+- Switched from numpy `isnan` to pandas `isnull` in StateBuilder. This allows nullable pandas Int64 dtypes to work as columns
 
 ## [2.1.0] — 2020-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This should remove some of the boilerplate one writes every time you want to get
 ## [2.1.1] — 2020-08-17
 
 ### Changed
+
 - Switched from numpy `isnan` to pandas `isnull` in StateBuilder. This allows nullable pandas Int64 dtypes to work as columns
 
 ## [2.1.0] — 2020-07-14

--- a/src/nglui/easyviewer/base.py
+++ b/src/nglui/easyviewer/base.py
@@ -103,7 +103,9 @@ class EasyViewer(neuroglancer.Viewer):
         layer_name=None,
         color=None,
         linked_segmentation_layer=None,
-        filter_by_segmentation=True,
+        filter_by_segmentation=False,
+        brackets_show_segmentation=True,
+        selection_shows_segmentation=True,
         tags=None,
     ):
         """Add annotation layer to the viewer instance.
@@ -123,6 +125,8 @@ class EasyViewer(neuroglancer.Viewer):
             new_layer = neuroglancer.AnnotationLayer(
                 linked_segmentation_layer=linked_segmentation_layer,
                 filter_by_segmentation=filter_by_segmentation,
+                brackets_show_segmentation=brackets_show_segmentation,
+                selection_shows_segmentation=selection_shows_segmentation,
             )
             s.layers.append(name=layer_name, layer=new_layer)
             if color is not None:

--- a/src/nglui/nglite/viewer_state.py
+++ b/src/nglui/nglite/viewer_state.py
@@ -180,7 +180,8 @@ class PointAnnotationLayer(Layer):
             *args, type="pointAnnotation", **kwargs
         )
 
-    points = wrapped_property("points", typed_list(array_wrapper(np.float32, 3)))
+    points = wrapped_property(
+        "points", typed_list(array_wrapper(np.float32, 3)))
 
 
 def volume_source(x):
@@ -243,7 +244,8 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
     __slots__ = ()
 
     def __init__(self, *args, **kwargs):
-        super(SegmentationLayer, self).__init__(*args, type="segmentation", **kwargs)
+        super(SegmentationLayer, self).__init__(
+            *args, type="segmentation", **kwargs)
 
     source = wrapped_property("source", optional(volume_source))
     mesh = wrapped_property("mesh", optional(text_type))
@@ -259,8 +261,10 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
     not_selected_alpha = notSelectedAlpha = wrapped_property(
         "notSelectedAlpha", optional(float, 0)
     )
-    object_alpha = objectAlpha = wrapped_property("objectAlpha", optional(float, 1.0))
-    skeleton_shader = skeletonShader = wrapped_property("skeletonShader", text_type)
+    object_alpha = objectAlpha = wrapped_property(
+        "objectAlpha", optional(float, 1.0))
+    skeleton_shader = skeletonShader = wrapped_property(
+        "skeletonShader", text_type)
     color_seed = colorSeed = wrapped_property("colorSeed", optional(int, 0))
     cross_section_render_scale = crossSectionRenderScale = wrapped_property(
         "crossSectionRenderScale", optional(float, 1)
@@ -316,7 +320,8 @@ class SingleMeshLayer(Layer):
 class AnnotationBase(JsonObjectWrapper):
     __slots__ = ()
 
-    id = wrapped_property("id", optional(text_type))  # pylint: disable=invalid-name
+    id = wrapped_property("id", optional(text_type)
+                          )  # pylint: disable=invalid-name
     type = wrapped_property("type", text_type)
     description = wrapped_property("description", optional(text_type))
     segments = wrapped_property("segments", optional(typed_list(np.uint64)))
@@ -363,7 +368,8 @@ class EllipsoidAnnotation(AnnotationBase):
     __slots__ = ()
 
     def __init__(self, *args, **kwargs):
-        super(EllipsoidAnnotation, self).__init__(*args, type="ellipsoid", **kwargs)
+        super(EllipsoidAnnotation, self).__init__(
+            *args, type="ellipsoid", **kwargs)
 
     center = wrapped_property("center", array_wrapper(np.float32, 3))
     radii = wrapped_property("radii", array_wrapper(np.float32, 3))
@@ -374,7 +380,8 @@ class CollectionAnnotation(AnnotationBase):
     __slots__ = ()
 
     def __init__(self, *args, **kwargs):
-        super(CollectionAnnotation, self).__init__(*args, type="collection", **kwargs)
+        super(CollectionAnnotation, self).__init__(
+            *args, type="collection", **kwargs)
 
     source = wrapped_property("source", array_wrapper(np.float32, 3))
     entries = wrapped_property("entries", array_wrapper(list))
@@ -398,7 +405,8 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     __slots__ = ()
 
     def __init__(self, *args, **kwargs):
-        super(AnnotationLayer, self).__init__(*args, type="annotation", **kwargs)
+        super(AnnotationLayer, self).__init__(
+            *args, type="annotation", **kwargs)
 
     source = wrapped_property("source", optional(volume_source))
     voxel_size = voxelSize = wrapped_property(
@@ -410,6 +418,12 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     )
     filter_by_segmentation = filterBySegmentation = wrapped_property(
         "filterBySegmentation", optional(bool, False)
+    )
+    brackets_show_segmentation = bracketShowSegmentation = wrapped_property(
+        "bracketShortcutsShowSegmentation", optional(bool, True)
+    )
+    selection_shows_segmentation = annotationSelectionShowsSegmentation = wrapped_property(
+        "annotationSelectionShowsSegmentation", optional(bool, True)
     )
 
     @staticmethod
@@ -467,7 +481,8 @@ class ManagedLayer(JsonObjectWrapper):
             layer = make_layer(json_data, _readonly=_readonly)
 
         object.__setattr__(self, "layer", layer)
-        super(ManagedLayer, self).__init__(json_data, _readonly=_readonly, **kwargs)
+        super(ManagedLayer, self).__init__(
+            json_data, _readonly=_readonly, **kwargs)
 
     visible = wrapped_property("visible", optional(bool))
 
@@ -641,7 +656,8 @@ def make_linked_navigation_type(value_type, interpolate_function=None):
 
     class LinkedType(JsonObjectWrapper):
         __slots__ = ()
-        link = wrapped_property("link", optional(navigation_link_type, u"linked"))
+        link = wrapped_property("link", optional(
+            navigation_link_type, u"linked"))
         value = wrapped_property("value", optional(value_type))
 
         @staticmethod
@@ -688,7 +704,8 @@ class CrossSection(JsonObjectWrapper):
         c = copy.deepcopy(a)
         c.width = interpolate_linear(a.width, b.width, t)
         c.height = interpolate_linear(a.height, b.height, t)
-        c.position = LinkedSpatialPosition.interpolate(a.position, b.position, t)
+        c.position = LinkedSpatialPosition.interpolate(
+            a.position, b.position, t)
         c.orientation = LinkedOrientationState.interpolate(
             a.orientation, b.orientation, t
         )
@@ -711,7 +728,8 @@ class CrossSectionMap(typed_string_map(CrossSection)):
 class DataPanelLayout(JsonObjectWrapper):
     __slots__ = ()
     type = wrapped_property("type", text_type)
-    cross_sections = crossSections = wrapped_property("crossSections", CrossSectionMap)
+    cross_sections = crossSections = wrapped_property(
+        "crossSections", CrossSectionMap)
     orthographic_projection = orthographicProjection = wrapped_property(
         "orthographicProjection", optional(bool, False)
     )
@@ -719,7 +737,8 @@ class DataPanelLayout(JsonObjectWrapper):
     def __init__(self, json_data=None, _readonly=False, **kwargs):
         if isinstance(json_data, six.string_types):
             json_data = {"type": six.text_type(json_data)}
-        super(DataPanelLayout, self).__init__(json_data, _readonly=_readonly, **kwargs)
+        super(DataPanelLayout, self).__init__(
+            json_data, _readonly=_readonly, **kwargs)
 
     def to_json(self):
         if len(self.cross_sections) == 0 and not self.orthographic_projection:
@@ -905,7 +924,8 @@ class ViewerState(JsonObjectWrapper):
     perspective_orientation = perspectiveOrientation = wrapped_property(
         "perspectiveOrientation", optional(array_wrapper(np.float32, 4))
     )
-    show_slices = showSlices = wrapped_property("showSlices", optional(bool, True))
+    show_slices = showSlices = wrapped_property(
+        "showSlices", optional(bool, True))
     show_axis_lines = showAxisLines = wrapped_property(
         "showAxisLines", optional(bool, True)
     )
@@ -964,8 +984,10 @@ class ViewerState(JsonObjectWrapper):
     @staticmethod
     def interpolate(a, b, t):
         c = copy.deepcopy(a)
-        c.navigation = NavigationState.interpolate(a.navigation, b.navigation, t)
-        c.perspective_zoom = interpolate_zoom(a.perspective_zoom, b.perspective_zoom, t)
+        c.navigation = NavigationState.interpolate(
+            a.navigation, b.navigation, t)
+        c.perspective_zoom = interpolate_zoom(
+            a.perspective_zoom, b.perspective_zoom, t)
         c.perspective_orientation = quaternion_slerp(
             a.perspective_orientation, b.perspective_orientation, t
         )

--- a/src/nglui/parser/__init__.py
+++ b/src/nglui/parser/__init__.py
@@ -1,0 +1,1 @@
+from .base import *

--- a/src/nglui/parser/base.py
+++ b/src/nglui/parser/base.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+SEGMENTATION_LAYER_TYPES = ['segmentation', 'segmentation_with_graph']
+
 
 def layer_names(state):
     """Get all layer names in the state
@@ -46,7 +48,7 @@ def segmentation_layers(state):
     names : list
         List of layer names
     """
-    return [l['name'] for l in state['layers'] if l['type'] == 'segmentation']
+    return [l['name'] for l in state['layers'] if l['type'] in SEGMENTATION_LAYER_TYPES]
 
 
 def annotation_layers(state):

--- a/src/nglui/parser/base.py
+++ b/src/nglui/parser/base.py
@@ -86,7 +86,7 @@ def tag_dictionary(state, layer_name):
     taginfo = l.get('annotationTags', [])
     tags = {}
     for t in taginfo:
-        tags[int(['id'])] = t['label']
+        tags[int(t['id'])] = t['label']
     return tags
 
 
@@ -126,9 +126,9 @@ def view_settings(state):
     """
     view = {}
     view['position'] = state['navigation']['pose']['position']['voxelCoordinates']
-    view['zoomFactor'] = state['zoomFactor']
-    view['perspectiveOrientation'] = state['perspectiveOrientation']
-    view['perspectiveZoom'] = state['perspectiveZoom']
+    view['zoomFactor'] = state['navigation'].get('zoomFactor', None)
+    view['perspectiveOrientation'] = state.get('perspectiveOrientation', None)
+    view['perspectiveZoom'] = state.get('perspectiveZoom', None)
     view['voxelSize'] = state['navigation']['pose']['position']['voxelSize']
     return view
 

--- a/src/nglui/parser/base.py
+++ b/src/nglui/parser/base.py
@@ -1,0 +1,148 @@
+import numpy as npj
+
+
+def layer_names(state):
+    """ Get layer names from a neuroglancer json state """
+    return [l['name'] for l in state['layers']]
+
+
+def image_layers(state):
+    return [l['name'] for l in state['layers'] if l['type'] == 'image']
+
+
+def segmentation_layers(state):
+    return [l['name'] for l in state['layers'] if l['type'] == 'segmentation']
+
+
+def annotation_layers(state):
+    return [l['name'] for l in state['layers'] if l['type'] == 'annotation']
+
+
+def view_settings(state):
+    view = {}
+    view['position'] = state['navigation']['pose']['position']['voxelCoordinates']
+    view['zoomFactor'] = state['zoomFactor']
+    view['perspectiveOrientation'] = state['perspectiveOrientation']
+    view['perspectiveZoom'] = state['perspectiveZoom']
+    view['voxelSize'] = state['navigation']['pose']['position']['voxelSize']
+    return view
+
+
+def get_annotations(state, layers=None, linked_segmentations=False, descriptions=False, tags=False, collapse_single=True, annotation_types='point'):
+    if layers is None:
+        layers = annotation_layers(state)
+
+    if isinstance(layers, str):
+        layers = [layers]
+
+    if len(layers) == 1 and collapse_single:
+        return_single = True
+    else:
+        return_single = False
+
+    if isinstance(annotation_types, str):
+        annotation_types = [annotation_types]
+        single_anno = True
+    else:
+        single_anno = False
+
+    annotations = {}
+    for ln in layers:
+        annotations[ln] = {}
+
+        for l in state['layers']:
+            if l.name == ln:
+                break
+        else:
+            continue
+
+        annos = l['annotations']
+        for at in annotation_types:
+
+    return out
+
+
+def _layer_from_name(state, layer_name):
+    for l in state['layers']:
+        if l['name'] == layer_name:
+            return l
+    else:
+        return None
+
+
+def _get_type_annotations(state, layer_name, type):
+    l = _layer_from_name(state, layer_name)
+    annos = l.get('annotations', [])
+    return [anno for anno in annos if anno['type'] == type]
+
+
+def _get_point_annotations(state, layer_name):
+    return _get_type_annotations(state, layer_name, 'point')
+
+
+def _get_sphere_annotations(state, layer_name):
+    return _get_type_annotations(state, layer_name, 'ellipsoid')
+
+
+def _get_line_annotations(state, layer_name):
+    return _get_type_annotations(state, layer_name, 'line')
+
+
+def _extract_point_data(annos):
+    return [[anno.get('point') for anno in annos]]
+
+
+def _extract_sphere_data(annos):
+    pt = [anno.get('center') for anno in annos]
+    rad = [anno.get('radii') for anno in annos]
+    return [pt, rad]
+
+
+def _extract_line_data(annos):
+    ptA = [anno.get('pointA') for anno in annos]
+    ptB = [anno.get('pointB') for anno in annos]
+    return [ptA, ptB]
+
+
+_get_map = {
+    'point': _get_point_annotations,
+    'line': _get_line_annotations,
+    'sphere': _get_sphere_annotations,
+}
+
+_extraction_map = {
+    'point': _extract_point_data,
+    'line': _extract_line_data,
+    'sphere': _extract_sphere_data
+}
+
+
+def _generic_annotations(state, layer_name, description, linked_segmentations, tags, type):
+    annos = _get_map[type](state, layer_name)
+    out = _extraction_map[type](annos)
+    if description:
+        desc = [anno.get('description', None) for anno in annos]
+        out.append(desc)
+    if linked_segmentations:
+        linked_seg = [[np.uint64(x) for x in anno.get(
+            'segments', [])] for anno in annos]
+        out.append(linked_seg)
+    if tags:
+        tag_list = [anno.get('tagIds', []) for anno in annos]
+        out.append(tag_list)
+    if len(out) == 1:
+        return out[0]
+    else:
+        return out
+
+
+def point_annotations(state, layer_name, description=False, linked_segmentations=False, tags=False):
+    return _generic_annotations(state, layer_name, description, linked_segmentations, tags, 'point')
+
+
+def line_annotations(state, layer_name, description=False, linked_segmentations=False, tags=False):
+    return _generic_annotations(state, layer_name, description, linked_segmentations, tags, 'line')
+
+
+def sphere_annotations(state, layer_name, description=False, linked_segmentations=False, tags=False):
+    return _generic_annotations(state, layer_name, description, linked_segmentations, tags, 'sphere')

--- a/src/nglui/statebuilder/statebuilder.py
+++ b/src/nglui/statebuilder/statebuilder.py
@@ -309,10 +309,16 @@ class AnnotationLayerConfig(LayerConfigBase):
                  array_data=False,
                  tags=None,
                  active=True,
+                 filter_by_segmentation=False,
+                 brackets_show_segmentation=True,
+                 selection_shows_segmentation=True,
                  ):
         super(AnnotationLayerConfig, self).__init__(
             name=name, type='annotation', color=color, source=None, active=active)
         self._config['linked_segmentation_layer'] = linked_segmentation_layer
+        self._config['filter_by_segmentation'] = filter_by_segmentation
+        self._config['selection_shows_segmentation'] = selection_shows_segmentation
+        self._config['brackets_show_segmentation'] = brackets_show_segmentation
         if issubclass(type(mapping_rules), AnnotationMapperBase):
             mapping_rules = [mapping_rules]
         if array_data is True:
@@ -329,10 +335,25 @@ class AnnotationLayerConfig(LayerConfigBase):
     def linked_segmentation_layer(self):
         return self._config.get('linked_segmentation_layer', None)
 
+    @property
+    def filter_by_segmentation(self):
+        return self._config.get('filter_by_segmentation', None)
+
+    @property
+    def selection_shows_segmentation(self):
+        return self._config.get('selection_shows_segmentation', None)
+
+    @property
+    def brackets_show_segmentation(self):
+        return self._config.get('brackets_show_segmentation', None)
+
     def _specific_rendering(self, viewer, data):
         viewer.add_annotation_layer(self.name,
                                     color=self.color,
                                     linked_segmentation_layer=self.linked_segmentation_layer,
+                                    filter_by_segmentation=self.filter_by_segmentation,
+                                    selection_shows_segmentation=self.selection_shows_segmentation,
+                                    brackets_show_segmentation=self.brackets_show_segmentation,
                                     tags=self._tags)
         annos = []
         for rule in self._annotation_map_rules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from nglui import EasyViewer
 import pandas as pd
 import numpy as np
+import json
 
 
 @pytest.fixture(scope='session')
@@ -50,3 +51,10 @@ def pre_syn_df():
 @pytest.fixture(scope='function')
 def post_syn_df():
     return pd.read_hdf('tests/testdata/test_data.h5', 'postsyn').head(5)
+
+
+@pytest.fixture(scope='session')
+def test_state():
+    with open('tests/testdata/test_state.json', 'r') as f:
+        state = json.load(f)
+    return state

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,50 @@
+import pytest
+import numpy as np
+import pandas as pd
+from nglui import parser
+
+
+def test_layer_names(test_state):
+    layer_names = parser.layer_names(test_state)
+    assert len(layer_names) == 3
+    assert 'synapses' in layer_names
+
+
+def test_layers(test_state):
+    img_layer = parser.image_layers(test_state)
+    assert len(img_layer) == 1
+    assert img_layer[0] == 'imagery'
+
+    seg_layers = parser.segmentation_layers(test_state)
+    assert len(seg_layers) == 1
+    assert seg_layers[0] == 'segments'
+
+    anno_layers = parser.annotation_layers(test_state)
+    assert len(anno_layers) == 1
+    assert anno_layers[0] == 'synapses'
+
+    lyr = parser.get_layer(test_state, anno_layers[0])
+    assert isinstance(lyr, dict)
+    assert lyr['name'] == anno_layers[0]
+
+
+def test_tag_dictionary(test_state):
+    tags = parser.tag_dictionary(test_state, 'synapses')
+    assert tags[1] == 'ChC'
+
+
+def test_view_settings(test_state):
+    view = parser.view_settings(test_state)
+    assert view['perspectiveZoom'] == 1500
+
+
+def test_annotation_parsing(test_state):
+    points = parser.point_annotations(test_state, 'synapses')
+    assert len(points) == 6
+    assert points[2][2] == 1440
+
+    points, desc, tags = parser.point_annotations(test_state, 'synapses',
+                                                  description=True, tags=True)
+    assert len(desc) == len(tags)
+    assert desc[1] is None
+    assert tags[4][0] == 1

--- a/tests/test_statebuilder.py
+++ b/tests/test_statebuilder.py
@@ -28,11 +28,12 @@ def anno_layer_basic():
 
 def test_basic(image_layer, seg_layer_basic, anno_layer_basic):
     sb = StateBuilder([image_layer, seg_layer_basic, anno_layer_basic])
-    state = sb.render_state()
-    assert len(state) == 642
+    state_url = sb.render_state()
+    assert state_url[:4] == 'http'
 
     state = sb.render_state(return_as='html')
-    assert len(state.data) == 690
+    # padding for link html plus text
+    assert state.data == f'<a href="{state_url}" target="_blank">Neuroglancer Link</a>'
 
     state = sb.render_state(return_as='dict')
     assert isinstance(state, OrderedDict)

--- a/tests/testdata/test_state.json
+++ b/tests/testdata/test_state.json
@@ -1,0 +1,174 @@
+{
+  "layers": [
+    {
+      "source": "precomputed://gs://neuroglancer/pinky100_v0/son_of_alignment_v15_rechunked",
+      "type": "image",
+      "blend": "default",
+      "shaderControls": {},
+      "name": "imagery"
+    },
+    {
+      "source": "precomputed://gs://microns_public_datasets/pinky100_v185/seg",
+      "type": "segmentation",
+      "selectedAlpha": 0.2,
+      "objectAlpha": 0.95,
+      "segmentColors": {
+        "648518346349538689": "#fcaf93",
+        "648518346346300466": "#aa1016",
+        "648518346349538682": "#d52221",
+        "648518346349463803": "#f44f39",
+        "648518346349519354": "#ffffff",
+        "648518346349538677": "#fc8161"
+      },
+      "segments": [
+        "648518346346300466",
+        "648518346349463803",
+        "648518346349519354",
+        "648518346349538677",
+        "648518346349538682",
+        "648518346349538689"
+      ],
+      "skeletonRendering": {
+        "mode2d": "lines_and_points",
+        "mode3d": "lines"
+      },
+      "name": "segments"
+    },
+    {
+      "annotationColor": "#ffffff",
+      "type": "annotation",
+      "annotations": [
+        {
+          "point": [
+            97087,
+            55441,
+            1462
+          ],
+          "type": "point",
+          "id": "9f8523ab5415e7602ecd879129a0211d9a0f4c5e",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346349538689"
+          ]
+        },
+        {
+          "point": [
+            96557,
+            53475,
+            1413
+          ],
+          "type": "point",
+          "id": "690c46adda481102945d1d30c6c926d68c904f2a",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346349538682"
+          ]
+        },
+        {
+          "point": [
+            96864,
+            54279,
+            1440
+          ],
+          "type": "point",
+          "id": "7239cb6717ff329954ce513b1740276a00694989",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346349538677"
+          ]
+        },
+        {
+          "point": [
+            96760,
+            53691,
+            1399
+          ],
+          "type": "point",
+          "id": "d7844dfa62cf01d12e0139ff23322bb0f2203b82",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346349463803"
+          ]
+        },
+        {
+          "point": [
+            96712,
+            53735,
+            1395
+          ],
+          "type": "point",
+          "id": "41747fea593f9ce458bd7018678198954ef5fbb6",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346346300466"
+          ]
+        },
+        {
+          "point": [
+            96754,
+            53986,
+            1428
+          ],
+          "type": "point",
+          "id": "4be157ede72c894d6f90ff99cede2224f49c4da2",
+          "tagIds": [
+            1
+          ],
+          "segments": [
+            "648518346346300466"
+          ]
+        }
+      ],
+      "annotationTags": [
+        {
+          "id": 1,
+          "label": "ChC"
+        }
+      ],
+      "voxelSize": [
+        4,
+        4,
+        40
+      ],
+      "linkedSegmentationLayer": "segments",
+      "filterBySegmentation": true,
+      "bracketShortcutsShowSegmentation": false,
+      "annotationSelectionShowsSegmentation": false,
+      "name": "synapses"
+    }
+  ],
+  "navigation": {
+    "pose": {
+      "position": {
+        "voxelSize": [
+          4,
+          4,
+          40
+        ],
+        "voxelCoordinates": [
+          97087,
+          55441,
+          1462
+        ]
+      }
+    },
+    "zoomFactor": 8
+  },
+  "perspectiveZoom": 1500,
+  "showSlices": false,
+  "selectedLayer": {
+    "layer": "synapses",
+    "visible": true
+  },
+  "layout": "xy-3d"
+}


### PR DESCRIPTION
### Added

 - Parser submodule `nglui.parser` for quickly extracting data from neuroglancer states.
This should remove some of the boilerplate one writes every time you want to get data out of a state.

 - AnnotationLayerConfig now can take arguments about user interactions such as filtering by segmentation and bracket shortcuts showing segmentations.

 ### Changed

 - Default behavior for annotation layers now has filtering by segmentation turned off and bracket shortcuts showing segmentations turned on.
